### PR TITLE
corrected get temp dir logic

### DIFF
--- a/pytest_pipeline/core.py
+++ b/pytest_pipeline/core.py
@@ -115,7 +115,7 @@ class PipelineRun:
             root_test_dir = request.config.option.base_pipeline_dir
             if root_test_dir is None:
                 root_test_dir = os.path.join(
-                    tempfile.tempdir,
+                    tempfile.gettempdir(),
                     "pipeline_tests",
                 )
                 if not os.path.exists(root_test_dir):


### PR DESCRIPTION
as per doc, `tempfile.tempdir` only works if earlier `tempfile.gettempdir()` is executed. otherwise it sends `None` . So corrected this in core logic where tempdir is generated for the run.

Let me know if any more info is needed to accept this PR.

Thanks!